### PR TITLE
tested on windows 11 & added settings icon

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,31 @@
 # Rusty Twinkle Tray
 
-A WIP Twinkle Tray rewrite in Rust
+Rusty Twinkle Tray is a work-in-progress (WIP) rewrite of Twinkle Tray in Rust.
+
+## Overview
+
+The project is organized into several modules, including ```monitors```, ```utils```, ```window```, and others. It uses the windows crate for Windows API bindings and the log crate for logging.
+
+The main entry point of the application is ```src/main.rs```.
+
+The application uses a custom window class XamlWindow and handles various window events.
+
+The project also includes a justfile for task running.
+
+## Codegen
+
+The project uses a custom code generation tool located in ```lib/codegen```.
+
+This tool generates Rust bindings for specified Windows classes and features.
+
+The configuration for this tool is located in ```lib/windows-ext/Codegen.toml```.
+
+## Dependencies
+
+The project has several dependencies, including ```windows```, ```log```, and ```windows-ext```. 
+
+The windows-ext is a local package that extends the ```windows``` crate with additional bindings.
 
 ## License
+
 MIT License

--- a/app.manifest
+++ b/app.manifest
@@ -5,6 +5,9 @@
             <!-- Windows 10 -->
             <maxversiontested Id="10.0.18362.0"/>
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+            <!-- Windows 11 -->
+            <maxversiontested Id="10.0.22509.0"/>
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
         </application>
     </compatibility>
 </assembly>

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,25 @@ impl WindowClass for XamlWindow {
         unsafe { interop.AttachToWindow(parent)?; }
         let island = unsafe { interop.WindowHandle() }?;
         //let icon_font = FontFamily::new(&HSTRING::from("Segoe Fluent Icons"))?;
+        let main_grid = Grid::new()?; // Create a new grid to hold the main stackpanel and the bottom bar
+        main_grid.SetBackground(&{
+            let brush = AcrylicBrush::new()?;
+            let color = Color { R: 70, G: 70, B: 70, A: 255 };
+            brush.SetBackgroundSource(AcrylicBackgroundSource::HostBackdrop)?;
+            brush.SetFallbackColor(color)?;
+            brush.SetTintColor(color)?;
+            brush.SetTintOpacity(0.7)?;
+            brush
+        })?;
+        main_grid.SetRequestedTheme(ElementTheme::Dark)?;
+        main_grid.SetRowSpacing(8.0)?;
+        main_grid.SetPadding(Thickness {
+            Left: 8.0,
+            Top: 8.0,
+            Right: 8.0,
+            Bottom: 8.0,
+        })?;
+
         let stack_panel = StackPanel::new()?;
         stack_panel.SetBackground(&{
             let brush = AcrylicBrush::new()?;
@@ -90,6 +109,7 @@ impl WindowClass for XamlWindow {
             brush.SetTintOpacity(0.7)?;
             brush
         })?;
+
         stack_panel.SetRequestedTheme(ElementTheme::Dark)?;
         stack_panel.SetSpacing(8.0)?;
         stack_panel.SetPadding(Thickness {
@@ -198,20 +218,29 @@ impl WindowClass for XamlWindow {
                 children.Append(&text_box)?;
                 grid
             })?;
-            // Will need to be moved to new row eventually
-            children.Append(&{
-                let icon = FontIcon::new()?;
-                icon.SetGlyph(&HSTRING::from("\u{E713}"))?; // Settings icon
-                icon.SetFontWeight(FontWeight { Weight: 500 })?;
-                icon.SetHorizontalAlignment(HorizontalAlignment::Right)?;
-                icon.SetVerticalAlignment(VerticalAlignment::Bottom)?;
-                icon
-            })?;
             stack_panel
         })?;
 
+        // Create a new stack panel for the bottom bar
+        let bottom_bar = StackPanel::new()?;
+        bottom_bar.SetOrientation(Orientation::Horizontal)?;
+        bottom_bar.SetVerticalAlignment(VerticalAlignment::Bottom)?;
+        bottom_bar.SetHorizontalAlignment(HorizontalAlignment::Right)?;
+        let bottom_bar_children = bottom_bar.Children()?;
+        bottom_bar_children.Append(&{
+            let icon = FontIcon::new()?;
+            icon.SetGlyph(&HSTRING::from("\u{E713}"))?; // Modern Windows 11 Settings icon
+            icon.SetFontWeight(FontWeight { Weight: 500 })?; // Add more padding from margins
+            icon
+        })?;
+
+        // Add the main stack panel and the bottom bar to the main grid
+        let main_grid_children = main_grid.Children()?;
+        main_grid_children.Append(&stack_panel)?;
+        main_grid_children.Append(&bottom_bar)?;
+
         //button.SetContent(&IInspectable::try_from("Hello World")?)?;
-        desktop_source.SetContent(&stack_panel)?;
+        desktop_source.SetContent(&main_grid)?;
         Ok(Self {
             parent_hwnd: parent,
             child_hwnd: island,

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,12 +225,29 @@ impl WindowClass for XamlWindow {
         let bottom_bar = StackPanel::new()?;
         bottom_bar.SetOrientation(Orientation::Horizontal)?;
         bottom_bar.SetVerticalAlignment(VerticalAlignment::Bottom)?;
-        bottom_bar.SetHorizontalAlignment(HorizontalAlignment::Right)?;
+        bottom_bar.SetHorizontalAlignment(HorizontalAlignment::Stretch)?;
+        bottom_bar.SetSpacing(230.0)?;
         let bottom_bar_children = bottom_bar.Children()?;
+
+        bottom_bar_children.Append(&{
+            let text_block = TextBlock::new()?;
+            text_block.SetText(&HSTRING::from("Adjust Brightness"))?;
+            text_block.SetHorizontalAlignment(HorizontalAlignment::Left)?;
+            text_block.SetFontSize(15.0)?;
+            text_block
+        })?;
+
         bottom_bar_children.Append(&{
             let icon = FontIcon::new()?;
             icon.SetGlyph(&HSTRING::from("\u{E713}"))?; // Modern Windows 11 Settings icon
-            icon.SetFontWeight(FontWeight { Weight: 500 })?; // Add more padding from margins
+            icon.SetFontWeight(FontWeight { Weight: 500 })?;
+            icon.SetHorizontalAlignment(HorizontalAlignment::Right)?;
+            icon.SetMargin(Thickness {
+                Left: 0.0,
+                Top: 0.0,
+                Right: 200.0, // Add right padding
+                Bottom: 0.0,
+            })?;
             icon
         })?;
 
@@ -239,7 +256,6 @@ impl WindowClass for XamlWindow {
         main_grid_children.Append(&stack_panel)?;
         main_grid_children.Append(&bottom_bar)?;
 
-        //button.SetContent(&IInspectable::try_from("Hello World")?)?;
         desktop_source.SetContent(&main_grid)?;
         Ok(Self {
             parent_hwnd: parent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use windows::Win32::System::WinRT::{RO_INIT_SINGLETHREADED, RoInitialize, RoUnin
 use windows::Win32::UI::WindowsAndMessaging::*;
 use windows_ext::UI::Xaml::Controls::{ColumnDefinition, FontIcon, Grid, Orientation, Slider, StackPanel, TextBlock};
 use windows_ext::UI::Xaml::Hosting::{DesktopWindowXamlSource, WindowsXamlManager};
-use windows_ext::UI::Xaml::{ElementTheme, GridLength, GridUnitType, TextAlignment, Thickness, VerticalAlignment};
+use windows_ext::UI::Xaml::{ElementTheme, GridLength, GridUnitType, HorizontalAlignment, TextAlignment, Thickness, VerticalAlignment};
 use windows_ext::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventHandler;
 use windows_ext::UI::Xaml::Input::PointerEventHandler;
 use windows_ext::UI::Xaml::Media::{AcrylicBackgroundSource, AcrylicBrush};
@@ -179,7 +179,7 @@ impl WindowClass for XamlWindow {
                     slider.SetValue2(slider.Value()? + delta as f64)?;
                     Ok(())
                 }))?;
-                //text_box.TextChanging(&TypedEventHandler::new({
+                // text_box.TextChanging(&TypedEventHandler::new({
                 //    let slider = slider.clone();
                 //    move |sender: &Option<TextBox>, _| {
                 //        let sender = sender.as_ref().some()?;
@@ -192,11 +192,20 @@ impl WindowClass for XamlWindow {
                 //        }
                 //        Ok(())
                 //    }
-                //}))?;
+                // }))?;
                 let children = grid.Children()?;
                 children.Append(&slider)?;
                 children.Append(&text_box)?;
                 grid
+            })?;
+            // Will need to be moved to new row eventually
+            children.Append(&{
+                let icon = FontIcon::new()?;
+                icon.SetGlyph(&HSTRING::from("\u{E713}"))?; // Settings icon
+                icon.SetFontWeight(FontWeight { Weight: 500 })?;
+                icon.SetHorizontalAlignment(HorizontalAlignment::Right)?;
+                icon.SetVerticalAlignment(VerticalAlignment::Bottom)?;
+                icon
             })?;
             stack_panel
         })?;


### PR DESCRIPTION
Files adjusted:
```app.manifest```
```src/main.rs```

I tested on Windows 11 Version 22H2 and added that to the app.manifest.

### Here is a screenshot of how it looks on my screen:

![Screenshot 2023-12-25 134117](https://github.com/sidit77/rusty-twinkle-tray/assets/73977662/8b1390ae-ee0e-44fb-996a-32cc4457ae11)

### For main.rs:
You can see the settings icon I added. I would like to get it along the bottom of the window like in TwinkleTray in a new row. We could add it to the top right to keep it in the text_box row.

